### PR TITLE
An empty envelope does not raise any Error

### DIFF
--- a/suds/__init__.py
+++ b/suds/__init__.py
@@ -26,8 +26,8 @@ import sys
 # Project properties
 #
 
-__version__ = '0.4.2-beta'
-__build__="(beta) 20161128"
+__version__ = '0.4.2'
+__build__="20161206"
 
 #
 # Exceptions

--- a/suds/__init__.py
+++ b/suds/__init__.py
@@ -26,8 +26,8 @@ import sys
 # Project properties
 #
 
-__version__ = '0.4.1'
-__build__="(beta) R705-20101207"
+__version__ = '0.4.2-beta'
+__build__="(beta) 20161128"
 
 #
 # Exceptions

--- a/suds/bindings/document.py
+++ b/suds/bindings/document.py
@@ -71,8 +71,10 @@ class Document(Binding):
 
     def replycontent(self, method, body):
         wrapped = method.soap.output.body.wrapped
-        if wrapped:
+        if wrapped and body:
             return body[0].children
+        elif wrapped:
+            return []
         else:
             return body.children
         


### PR DESCRIPTION
Fix bug that causes an exception when SOAP returns an empty envelope.
See `ableton.com` `suds-fix` branch.